### PR TITLE
Add option to keep output directory as is

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Below are the parameters that can be used to configure the build:
 | `validateXml`       | `boolean`                    | Validate source files before compiling. Default value: `true`                                 |
 | `verbose`           | `boolean`                    | Verbose plugin outpout. Default value: `false`                                                |
 | `useRelativeOutDir` | `boolean`                    | The outDir is relative to java classpath. Default value: `true`                               |
+| `clearOutDir`       | `boolean`                    | If output directory should be clear before plugin execution. Default value: `true`            |
 | `classpath`         | `ConfigurableFileCollection` | Classpath to use for compilation. Default value: `<empty>`                                    |
 | `launcher`          | `JavaLauncher`               | Launcher from standard java toolchain                                                         |
 
@@ -95,6 +96,7 @@ Below is a complete example, with default values:
         validateXml = true
         verbose = false
         useRelativeOutDir = true
+        clearOutDir = true
         classpath.from()
     }
 

--- a/src/main/kotlin/com/github/fcramer/gradle/jasperreports/JasperReportsExtension.kt
+++ b/src/main/kotlin/com/github/fcramer/gradle/jasperreports/JasperReportsExtension.kt
@@ -38,4 +38,6 @@ abstract class JasperReportsExtension(
         .convention(false)
     val useRelativeOutDir: Property<Boolean> = project.objects.property<Boolean>()
         .convention(true)
+    val clearOutDir: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(true)
 }

--- a/src/main/kotlin/com/github/fcramer/gradle/jasperreports/JasperReportsPlugin.kt
+++ b/src/main/kotlin/com/github/fcramer/gradle/jasperreports/JasperReportsPlugin.kt
@@ -34,6 +34,7 @@ class JasperReportsPlugin : Plugin<Project> {
             useRelativeOutDir.convention(extension.useRelativeOutDir)
             keepJava.convention(extension.keepJava)
             validateXml.convention(extension.validateXml)
+            clearOutDir.convention(extension.clearOutDir)
         }
     }
 

--- a/src/main/kotlin/com/github/fcramer/gradle/jasperreports/tasks/JasperReportsCompileTask.kt
+++ b/src/main/kotlin/com/github/fcramer/gradle/jasperreports/tasks/JasperReportsCompileTask.kt
@@ -88,6 +88,10 @@ abstract class JasperReportsCompileTask : DefaultTask() {
     val validateXml: Property<Boolean> = project.objects.property<Boolean>()
         .convention(true)
 
+    @get:Input
+    val clearOutDir: Property<Boolean> = project.objects.property<Boolean>()
+        .convention(true)
+
     @get:Inject
     abstract val workerExecutor: WorkerExecutor
 
@@ -102,8 +106,8 @@ abstract class JasperReportsCompileTask : DefaultTask() {
             logDependencies()
         }
 
-        // delete all output if not incremental
-        if (!inputs.isIncremental) {
+        // delete all output if not incremental and clearOutDir is set
+        if (!inputs.isIncremental && clearOutDir.get()) {
             outDir.asFileTree.visit {
                 if (!isDirectory) {
                     file.delete()

--- a/src/test/kotlin/com/github/cramer/gradle/jasperreports/JasperReportsPluginTest.kt
+++ b/src/test/kotlin/com/github/cramer/gradle/jasperreports/JasperReportsPluginTest.kt
@@ -54,6 +54,7 @@ class JasperReportsPluginTest {
         assertThat(extension.validateXml.get()).isTrue()
         assertThat(extension.verbose.get()).isFalse()
         assertThat(extension.useRelativeOutDir.get()).isTrue()
+        assertThat(extension.clearOutDir.get()).isTrue()
     }
 
     @Test

--- a/src/test/kotlin/com/github/cramer/gradle/jasperreports/utils/CompilationUtilsTest.kt
+++ b/src/test/kotlin/com/github/cramer/gradle/jasperreports/utils/CompilationUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.github.cramer.gradle.jasperreports.utils
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isNotNull
 import com.github.cramer.gradle.jasperreports.getReportTemplateNameWithoutExtension
 import com.github.fcramer.gradle.jasperreports.commons.CompilationTask
@@ -23,6 +24,24 @@ class CompilationUtilsTest {
         val configuration =
             TaskConfiguration(compiler = null, isValidateXml = true, isKeepJava = false, tmpDir = tmp, classpath = emptySet())
         compileReport(CompilationTask(input, output, configuration))
+    }
+
+    @Test
+    fun ignoresExistingFilesInOutputDir(@TempDir directory: File?) {
+        val fileName = getReportTemplateNameWithoutExtension()
+        val input = File(directory, "$fileName.jrxml")
+        writeFile("/" + input.name, input)
+        val output = File(directory, "$fileName.jasper")
+        val tmp = File(directory, "tmp")
+        // write some content into a file in output folder
+        val existingFileInOutput = File(directory, "existing.file")
+        writeFile("/" + input.name, existingFileInOutput)
+
+        val configuration =
+            TaskConfiguration(compiler = null, isValidateXml = true, isKeepJava = false, tmpDir = tmp, classpath = emptySet())
+        compileReport(CompilationTask(input, output, configuration))
+
+        assertThat(directory!!.listFiles().map { it.name }).contains("existing.file")
     }
 
     private fun writeFile(resource: String, file: File) {


### PR DESCRIPTION
First of all, thanks for this plugin, it helped us a lot!

We sadly needed an option to not forcefully clear the output directory, therefore this PR.
As the deletion of the output directory happens in `execute(inputs: InputChanges)` it is not that easy to properly test it, but I added a test to ensure the `CompilationTask` can handle the pre-existing files.

Happy for any feedback or input from your side :smile: 